### PR TITLE
Fixed resource group removal

### DIFF
--- a/Public/Remove-AzureVMDeployment.ps1
+++ b/Public/Remove-AzureVMDeployment.ps1
@@ -32,10 +32,10 @@ function Remove-AzureVMDeployment
         $securePassword = Get-SecurePassword -PasswdPath $PasswordFilePath -PasswordKey $script:PasswordKey
         Login-AzureAccount -UserName $UserName -SecurePassword $securePassword -SubscriptionId $SubscriptionId
 
-        Remove-AzureResourceGroup $ResourceGroupName
-
         $vmDomainName = Get-VMDomainName $ResourceGroupName
-        Add-VMDomainNameToTrustedHostsList $vmDomainName
+        Remove-VMDomainNameFromTrustedHostsList $vmDomainName
+
+        Remove-AzureResourceGroup $ResourceGroupName
     }
     catch
     {


### PR DESCRIPTION
Remove the VM's domain name first, while the resource group still exists, before deleting the resource group