### PR TITLE
Fixed error in resource group creation

### DIFF
--- a/Private/New-AzureResourceGroup.ps1
+++ b/Private/New-AzureResourceGroup.ps1
@@ -11,13 +11,13 @@ function New-AzureResourceGroup
 
     Write-Output "Creating resource group '$ResourceGroupName' at '$ResourceGroupLocation' to contain the VM and dependent resources"
 
-    $existingResourceGroup = Find-AzureRmResourceGroup -Tag @{ Name="Purpose";Value="Integration Testing" }
+    $existingResourceGroup = Find-AzureRmResourceGroup -Tag @{ Name = $ResourceGroupName }
     if ($existingResourceGroup)
     {
         throw "Resource group '$ResourceGroupName' at '$ResourceGroupLocation' already exists"
     }
 
-    $resourceGroup = New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Tag @{ Name="Purpose";Value="Integration Testing" } -Force
+    $resourceGroup = New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Tag @{ Name = $ResourceGroupName } -Force
     if (!$resourceGroup)
     {
         throw "Failed to create resource group '$ResourceGroupName' at '$ResourceGroupLocation'"

--- a/Private/Remove-AzureResourceGroup.ps1
+++ b/Private/Remove-AzureResourceGroup.ps1
@@ -9,7 +9,7 @@ function Remove-AzureResourceGroup
 
     Write-Output "Removing resource group '$ResourceGroupName'"
 
-    $existingResourceGroup = Find-AzureRmResourceGroup -Tag @{ Name="Purpose";Value="Integration Testing" }
+    $existingResourceGroup = Find-AzureRmResourceGroup -Tag @{ Name = $ResourceGroupName }
     if (!$existingResourceGroup)
     {
         Write-Output "Resource group '$ResourceGroupName' doesn't exist, no removal needed"


### PR DESCRIPTION
When creating a resource group, we embed a hashtable that had key values meant to uniquely identify the resource group. This was to work around limitations with the Find-AzureRmResourceGroup cmdlet. However, I forgot to remove hard coded values so simultaneous deployments failed as agents thought the desired resource group already existed.

@jameswelle