### PR TITLE
Disable Azure data collection

### DIFF
--- a/Modules/DesktopIntegrationTesting/Public/New-AzureVMDeployment.ps1
+++ b/Modules/DesktopIntegrationTesting/Public/New-AzureVMDeployment.ps1
@@ -26,6 +26,8 @@ function New-AzureVMDeployment
     {
         Set-StrictMode -Version Latest
 
+        Disable-AzureDataCollection
+
         Login-AzureRmAccount -Credential $Credentials -SubscriptionId $SubscriptionId
 
         New-AzureResourceGroup -ResourceGroupName $ResourceGroupName -ResourceGroupLocation $ResourceGroupLocation

--- a/Modules/DesktopIntegrationTesting/Public/Remove-AzureVMDeployment.ps1
+++ b/Modules/DesktopIntegrationTesting/Public/Remove-AzureVMDeployment.ps1
@@ -24,6 +24,8 @@ function Remove-AzureVMDeployment
     {
         Set-StrictMode -Version Latest
 
+        Disable-AzureDataCollection
+
         Login-AzureRmAccount -Credential $Credentials -SubscriptionId $SubscriptionId
 
         $vmDomainName = Get-VMDomainName $ResourceGroupName


### PR DESCRIPTION
Fixes a problem where the Azure PShell module prompts the user for permission to enable data collection, causing the build agent to stall.

We also know Disable-AzureDataCollection will *not* prompt the user: https://github.com/Azure/azure-powershell/issues/902

@jameswelle - just a heads up. Will merge to get the agents going again.